### PR TITLE
Persist: index new entity first so circular references don't loop

### DIFF
--- a/src/Model/IdentityMap.php
+++ b/src/Model/IdentityMap.php
@@ -27,6 +27,13 @@ class IdentityMap
 	 */
 	public array $uninitializedEntityList = [];
 
+	/**
+	 * entities currently being persisted (write side) - used to break circular references
+	 *
+	 * @var array<class-string, array<string, bool>>
+	 */
+	public array $persistingList = [];
+
 
 	public function add(
 		\Spameri\Elastic\Entity\AbstractElasticEntity $entity,
@@ -90,6 +97,42 @@ class IdentityMap
 	}
 
 
+	public function markPersisting(
+		\Spameri\Elastic\Entity\AbstractElasticEntity $entity,
+	): void
+	{
+		if ($entity->id instanceof \Spameri\Elastic\Entity\Property\EmptyElasticId) {
+			return;
+		}
+
+		$this->persistingList[$entity::class][$entity->id()->value()] = true;
+	}
+
+
+	public function unmarkPersisting(
+		\Spameri\Elastic\Entity\AbstractElasticEntity $entity,
+	): void
+	{
+		if ($entity->id instanceof \Spameri\Elastic\Entity\Property\EmptyElasticId) {
+			return;
+		}
+
+		unset($this->persistingList[$entity::class][$entity->id()->value()]);
+	}
+
+
+	public function isPersisting(
+		\Spameri\Elastic\Entity\AbstractElasticEntity $entity,
+	): bool
+	{
+		if ($entity->id instanceof \Spameri\Elastic\Entity\Property\EmptyElasticId) {
+			return false;
+		}
+
+		return isset($this->persistingList[$entity::class][$entity->id()->value()]);
+	}
+
+
 	public function isChanged(
 		\Spameri\Elastic\Entity\AbstractElasticEntity $entity,
 	): bool
@@ -128,6 +171,7 @@ class IdentityMap
 		$this->persisted = [];
 		$this->creatingEntityList = [];
 		$this->uninitializedEntityList = [];
+		$this->persistingList = [];
 	}
 
 }

--- a/src/Model/Insert.php
+++ b/src/Model/Insert.php
@@ -15,6 +15,17 @@ readonly class Insert
 
 
 	/**
+	 * New entities are indexed in two phases so that nested entities can reference
+	 * the parent (and circular references do not loop):
+	 *
+	 *  1. the parent is indexed first (empty body, no refresh) to obtain its id and
+	 *     is marked as "persisting" in the identity map,
+	 *  2. its nested entities are persisted - a back-reference to the parent now
+	 *     resolves to the parent's id instead of re-persisting it,
+	 *  3. the parent is re-indexed with the full body.
+	 *
+	 * Entities that already have an id are indexed once, as before.
+	 *
 	 * @throws \Spameri\Elastic\Exception\ElasticSearch
 	 * @throws \Spameri\Elastic\Exception\DocumentInsertFailed
 	 */
@@ -31,14 +42,42 @@ readonly class Insert
 			return $entity->id()->value();
 		}
 
-		// Only mark inserted for entities with real IDs (prevents collision on empty string key)
-		if ($hasRealId) {
-			$this->identityMap->markInserted($entity);
+		// New entity: index it first (shallow body) to obtain its id before its
+		// nested entities are persisted, so circular references can resolve to it.
+		if ($hasRealId === false) {
+			$this->index($entity, $index, $this->shallowBody($entity), false);
 		}
 
-		$entityArray = $this->prepareEntityArray->prepare($entity, $hasSti);
-		unset($entityArray['id']);
+		$this->identityMap->markInserted($entity);
+		$this->identityMap->markPersisting($entity);
 
+		try {
+			$entityArray = $this->prepareEntityArray->prepare($entity, $hasSti);
+			unset($entityArray['id']);
+
+			$id = $this->index($entity, $index, $entityArray, true);
+			$this->identityMap->markInserted($entity);
+
+			return $id;
+
+		} finally {
+			$this->identityMap->unmarkPersisting($entity);
+		}
+	}
+
+
+	/**
+	 * @param array<mixed> $entityArray
+	 * @throws \Spameri\Elastic\Exception\ElasticSearch
+	 * @throws \Spameri\Elastic\Exception\DocumentInsertFailed
+	 */
+	private function index(
+		\Spameri\Elastic\Entity\AbstractElasticEntity $entity,
+		string $index,
+		array $entityArray,
+		bool $refresh,
+	): string
+	{
 		try {
 			$response = $this->clientProvider->client()->index(
 				(
@@ -55,27 +94,52 @@ readonly class Insert
 			throw new \Spameri\Elastic\Exception\ElasticSearch($exception->getMessage());
 		}
 
-		try {
-			$this->clientProvider->client()->indices()->refresh(
-				(
-					new \Spameri\ElasticQuery\Document($index)
+		if ($refresh === true) {
+			try {
+				$this->clientProvider->client()->indices()->refresh(
+					(
+						new \Spameri\ElasticQuery\Document($index)
+					)
+						->toArray(),
 				)
-					->toArray(),
-			)
-			;
+				;
 
-		} catch (\Elastic\Elasticsearch\Exception\ElasticsearchException $exception) {
-			throw new \Spameri\Elastic\Exception\ElasticSearch($exception->getMessage());
+			} catch (\Elastic\Elasticsearch\Exception\ElasticsearchException $exception) {
+				throw new \Spameri\Elastic\Exception\ElasticSearch($exception->getMessage());
+			}
 		}
 
 		if (isset($response['result']) && ($response['result'] === 'created' || $response['result'] === 'updated')) {
 			$entity->id = new \Spameri\Elastic\Entity\Property\ElasticId($response['_id']);
-			$this->identityMap->markInserted($entity);
 
 			return $response['_id'];
 		}
 
 		throw new \Spameri\Elastic\Exception\DocumentInsertFailed();
+	}
+
+
+	/**
+	 * Minimal non-empty body for the first index of a new entity: every field
+	 * (except the id) nulled. The real values are written by the second index;
+	 * this only reserves the document so it gets a server generated id.
+	 *
+	 * @return array<string, null>
+	 */
+	private function shallowBody(
+		\Spameri\Elastic\Entity\AbstractElasticEntity $entity,
+	): array
+	{
+		$body = [];
+		foreach (\array_keys($entity->entityVariables()) as $key) {
+			if ($key === 'id') {
+				continue;
+			}
+
+			$body[$key] = null;
+		}
+
+		return $body;
 	}
 
 }

--- a/src/Model/Insert/PrepareEntityArray.php
+++ b/src/Model/Insert/PrepareEntityArray.php
@@ -111,7 +111,10 @@ class PrepareEntityArray
 
 					$preparedArray[$key][self::ENTITY_CLASS] = $property::class;
 
-					if ($this->identityMap->isChanged($property) === false) {
+					if (
+						$this->identityMap->isPersisting($property) === true
+						|| $this->identityMap->isChanged($property) === false
+					) {
 						$preparedArray[$key][self::ENTITY_ID] = $property->id()->value();
 
 					} else {
@@ -127,7 +130,10 @@ class PrepareEntityArray
 			}
 
 			if ($property instanceof \Spameri\Elastic\Entity\AbstractElasticEntity) {
-				if ($this->identityMap->isChanged($property) === false) {
+				if (
+					$this->identityMap->isPersisting($property) === true
+					|| $this->identityMap->isChanged($property) === false
+				) {
 					$preparedArray[$key] = $property->id()->value();
 
 				} else {
@@ -178,7 +184,10 @@ class PrepareEntityArray
 				} else {
 					/** @var \Spameri\Elastic\Entity\AbstractElasticEntity $item */
 					foreach ($property as $item) {
-						if ($this->identityMap->isChanged($item) === false) {
+						if (
+							$this->identityMap->isPersisting($item) === true
+							|| $this->identityMap->isChanged($item) === false
+						) {
 							$preparedArray[$key][] = $item->id()->value();
 
 						} else {

--- a/tests/SpameriTests/Elastic/EntityManager/PersistCircularTest.phpt
+++ b/tests/SpameriTests/Elastic/EntityManager/PersistCircularTest.phpt
@@ -1,0 +1,68 @@
+<?php declare(strict_types = 1);
+
+namespace SpameriTests\Elastic\EntityManager;
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+/**
+ * Persisting an entity whose nested elastic entities reference it back must not
+ * loop: the parent is indexed first (so it has an id), then the children are
+ * persisted referencing the parent, then the parent is re-indexed.
+ *
+ * @testCase
+ */
+class PersistCircularTest extends \SpameriTests\Elastic\AbstractTestCase
+{
+
+	public function testPersistCircularReference(): void
+	{
+		/** @var \Spameri\Elastic\EntityManager $entityManager */
+		$entityManager = $this->container->getByType(\Spameri\Elastic\EntityManager::class);
+
+		$title = new \SpameriTests\Elastic\Data\Entity\Title(
+			new \Spameri\Elastic\Entity\Property\EmptyElasticId(),
+			null,
+		);
+		$image = new \SpameriTests\Elastic\Data\Entity\Image(
+			new \Spameri\Elastic\Entity\Property\EmptyElasticId(),
+			$title,
+			true,
+		);
+		// circular reference: title -> image -> title
+		$title->backdrop = $image;
+
+		// must finish (no infinite loop) and assign both ids
+		\Tester\Assert::noError(
+			static function () use ($entityManager, $title): void {
+				$entityManager->persist($title);
+			},
+		);
+
+		\Tester\Assert::false($title->id() instanceof \Spameri\Elastic\Entity\Property\EmptyElasticId);
+		\Tester\Assert::false($image->id() instanceof \Spameri\Elastic\Entity\Property\EmptyElasticId);
+		\Tester\Assert::notSame('', $title->id()->value());
+		\Tester\Assert::notSame('', $image->id()->value());
+
+		// each side recorded the other's resolved id on the in-memory graph
+		\Tester\Assert::same($image->id()->value(), $title->backdrop->id()->value());
+		\Tester\Assert::same($title->id()->value(), $image->title->id()->value());
+
+		// read the stored documents and verify the references were persisted
+		$client = $this->container->getByType(\Spameri\Elastic\ClientProvider::class)->client();
+
+		$titleSource = $client->get([
+			'index' => \SpameriTests\Elastic\Config::INDEX_TITLE,
+			'id' => $title->id()->value(),
+		])->asArray()['_source'];
+		$imageSource = $client->get([
+			'index' => \SpameriTests\Elastic\Config::INDEX_IMAGE,
+			'id' => $image->id()->value(),
+		])->asArray()['_source'];
+
+		\Tester\Assert::same($image->id()->value(), $titleSource['backdrop']);
+		\Tester\Assert::same($title->id()->value(), $imageSource['title']);
+	}
+
+}
+
+(new PersistCircularTest())->run();


### PR DESCRIPTION
## Problem

Persisting a **new** entity (`EmptyElasticId`) whose nested elastic entity references it back loops forever. `Insert::execute` calls `PrepareEntityArray::prepare()` first, which persists the child; the child's `prepare()` persists the parent again, and so on. New entities aren't tracked in `IdentityMap` (their id is the empty string), so `isChanged()` always reports them as changed and they get re-persisted.

The v2.0 `Title`/`Image` fixtures (`Title.backdrop → Image`, `Image.title → Title`) are exactly this circular shape.

## Change

`Insert::execute` now saves a **new** entity in two phases:

1. Index it once with a **shallow (all-null) body** to obtain its id and register it as *persisting* in `IdentityMap`.
2. Prepare/persist its nested entities — a back-reference to the parent now resolves to the parent's id instead of re-persisting it.
3. Re-index it with the full body.

Entities that already have an id are still indexed once (unchanged).

### Details

- **`IdentityMap`** gains `persistingList` + `markPersisting()` / `unmarkPersisting()` / `isPersisting()` (and `clear()` resets it).
- **`PrepareEntityArray`** short-circuits to the referenced entity's id (instead of recursing) whenever it `isPersisting()`, for the nested `AbstractElasticEntity`, `ElasticEntityCollection` item, and `STIElasticEntity` cases. This guard is needed *in addition to* `isChanged()` because the parent's serialized hash changes as its children receive ids — so `isChanged()` alone would still re-enter the loop.
- The shallow first index uses an all-null body (every field except `id`), which is a valid non-empty document for any mapping; its content is irrelevant because phase 3 overwrites it. Only the second index refreshes, so there is one refresh per entity as before (one extra cheap index call for new entities).

## Test

`tests/SpameriTests/Elastic/EntityManager/PersistCircularTest.phpt` persists a `Title` whose `backdrop` is an `Image` whose `title` points back at the `Title`, and asserts: it terminates (no loop), both ids are assigned, the in-memory graph resolves both ids, and each stored document references the other.

```
$ vendor/bin/tester tests/SpameriTests/Elastic/EntityManager/PersistCircularTest.phpt
OK (1 test)
```

PHPStan (level 6) and CS are clean on the changed files.

> Note: the existing `PersistTest`/`InsertTest` are flaky in some environments because their `setUp` deletes + recreates indexes with a short sleep (and relies on wildcard deletes); the new test avoids this by using auto-create and reading documents back by id. That flakiness is pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)